### PR TITLE
added unique_sister_spp.R

### DIFF
--- a/rwty/R/output_plot.R
+++ b/rwty/R/output_plot.R
@@ -1,0 +1,38 @@
+# assumes a 3 column output
+
+library(coda)
+
+plot.results <- function(results){
+
+## Get info ##
+
+mcmc.res <- as.mcmc(data$Number.Unique.Sister.Taxa)
+
+hpd.res <- HPDinterval(mcmc.res)[,2]
+
+dd <- data[data$Number.Unique.Sister.Taxa > hpd.res,]
+
+dd <-  dd[order(dd$Number.Unique.Sister.Taxa, decreasing=TRUE),]
+
+
+legend.text <- paste(dd[,1],":",dd[,2])
+
+
+title.text <- paste("Upper 95% Confidence limit:",hpd.res)
+
+## Plot out ##
+l<-matrix(c(1,1,1,2,2), ncol=5, nrow=1)
+layout(l)
+
+# Plot 1
+
+plot(seq(1,nrow(data),1), data[,2],xlab="",pch=19,col="#0000FF80" ,ylab="Number of Unique Taxa", main=title.text)
+
+abline(h=hpd.res, lty=2, lwd=2, col="red")
+
+# Plot 2
+plot(1, type="n", axes=F, xlab="", ylab="")
+
+legend("left",legend.text,bty="n", cex=1.1)
+
+}

--- a/rwty/R/unique_sister_spp.R
+++ b/rwty/R/unique_sister_spp.R
@@ -1,0 +1,141 @@
+
+unique_sister_spp <- function(spp, multi.phy){
+
+require(phytools)
+require(vegan)
+
+if((length(spp)>1)==TRUE){
+stop("Only a single species can be passed to the function 'unique_sister_spp'")
+}
+
+# Find sisters species for target species from all trees in `multi.phy'
+o <-as.numeric(sapply(multi.phy, getSisters, spp))
+
+
+# If o is less than or equal to the length of the number of tips, it is a terminal taxa
+v <- o <= length(multi.phy[[1]]$tip.label)
+
+
+# Select those values corresponding to tips
+tips <- o[v==TRUE]
+
+
+if(length(tips) > 0){
+
+	phy.tips <- multi.phy[v==TRUE]
+
+	tip.names <- mapply(get.tip.names, tips, phy.tips)
+
+	unique.tip.names <- unique(tip.names)
+
+	tip.length <- length(unique.tip.names)
+
+	} else {
+
+	tip.length <- 0
+
+}
+
+
+# Sister clades
+
+node.locations <- o[v==FALSE]
+
+if(length(node.locations) > 0){
+
+	phy.sub <- multi.phy[v==FALSE]
+
+	node.clades <- mapply(extract.clade, phy.sub, node.locations, SIMPLIFY=FALSE)
+
+	# all.clades <- node.clades
+	# num.unique.clades <- length(unique(all.clades))
+
+	clade.tip.labels <- lapply(node.clades, get_clade_names)
+
+	clade.tip.labels <- lapply(clade.tip.labels, sort)
+
+	num.unique.clades <- length(unique(clade.tip.labels))
+
+	} else {
+
+	num.unique.clades <- 0
+
+}
+
+len <- tip.length + num.unique.clades
+
+
+
+
+## Part 2 - Diversity of sister taxa ##
+
+if(length(node.locations) > 0){
+
+# Unique clades present
+
+unique.clades <- unique(clade.tip.labels)
+
+# Counts how many times each unique clade appears in all identified clades
+clade.result <- vector()
+for(i in 1:length(unique.clades)){
+	clade <- unique.clades[[i]]
+	check.matches <- sapply(clade.tip.labels, all.equal, clade)
+	num.instances <- length(grep("TRUE",check.matches))
+	clade.result[i] <- num.instances
+}
+} else {
+clade.result <- "no.result"
+}
+
+if(length(tips) > 0){
+# Number of times each tip name appears
+tip.name.table <- table(tip.names)
+tip.name.table.numeric <- as.numeric(tip.name.table)
+} else {
+tip.name.table.numeric <- "no.result"
+}
+
+# Final numeric vector of number of times each unique tip and clade appear
+
+
+if(clade.result == "no.result" && tip.name.table.numeric != "no.result"){
+
+all.counts <- tip.name.table.numeric
+
+} else if(clade.result != "no.result" && tip.name.table.numeric == "no.result") {
+
+all.counts <- clade.result
+
+} else {
+
+all.counts <- c(clade.result, tip.name.table.numeric)
+}
+
+
+div <- diversity(all.counts, index="simpson")
+
+## Export results ##
+
+output.result <- as.data.frame(t(c(len, div)))
+
+colnames(output.result) <- c("Number.Unique.Sister.Taxa", "Diversity.of.Sister.Taxa")
+
+return(output.result)
+
+}
+
+###
+
+get.tip.names <- function(tip.numbers, phy){
+names <- phy$tip.label[tip.numbers]
+return(names)
+}
+
+###
+
+get_clade_names <- function(clade){
+names <- clade$tip.label
+return(names)
+}
+
+

--- a/rwty/R/unique_sister_spp.R
+++ b/rwty/R/unique_sister_spp.R
@@ -1,6 +1,10 @@
 
 unique_sister_spp <- function(spp, multi.phy){
 
+if((is.rooted(multi.phy[[1]])) == FALSE){
+stop("Trees are unrooted, please root before proceeding")
+}
+
 require(phytools)
 require(vegan)
 


### PR DESCRIPTION
The function to calculate the how many unique sister species/taxa a target species has, given a set of phylogenies (rwty issue #49).

There are 2 support functions present also, referenced by the main function so *pply functions can be used. 

The main function also calculates the diversity of sister taxa, using Simpson's diversity index