### PR TITLE
use overlapping samples for autocorrelation estimates

### DIFF
--- a/R/topological.approx.ess.R
+++ b/R/topological.approx.ess.R
@@ -9,7 +9,7 @@
 #'
 #' @param chains A list of rwty.trees objects. 
 #' @param burnin The number of trees to eliminate as burnin 
-#' @param max.interval The largest sampling interval you want to plot. Defaults to the largest possible sampling interval, which is the one for which we can sample at least 20 indpendent pairs of trees
+#' @param autocorr.intervals The number of sampling intervals you want to sample to calculate the ESS. Default 100. Higher is better, but will be slower. If you have a chain of N trees, the maximum interval is N-100. If you supply a larger number, it will default to N-100.
 #' @param treedist the type of tree distance metric to use, can be 'PD' for path distance or 'RF' for Robinson Foulds distance
 #'
 #' @return A data frame with one row per chain, and columns describing the
@@ -24,7 +24,7 @@
 
 
 
-topological.approx.ess <- function(chains, burnin = 0, max.interval = NA, treedist = 'PD'){
+topological.approx.ess <- function(chains, burnin = 0, autocorr.intervals = 100, treedist = 'PD'){
 
     chains = check.chains(chains)
 
@@ -32,11 +32,7 @@ topological.approx.ess <- function(chains, burnin = 0, max.interval = NA, treedi
     # this interval means the minimum number of samples is 20
     N = length(chains[[1]]$trees)
 
-    if(is.na(max.interval)){
-      max.interval = as.integer(N/21)
-    } 
-
-    autocorr.df = topological.autocorr(chains, burnin, max.interval, squared = TRUE, treedist = treedist)
+    autocorr.df = topological.autocorr(chains, burnin, autocorr.intervals, squared = TRUE, treedist = treedist)
 
     autocorr.m = estimate.autocorr.m(autocorr.df)
 

--- a/R/topological.autocorr.R
+++ b/R/topological.autocorr.R
@@ -58,7 +58,7 @@ tree.autocorr <- function(tree.list, autocorr.intervals = 100, squared = FALSE, 
 
     # this ensures that we can tell you if your ESS is < some threshold
     # the max(,2) bit is a fallback for extremely short tree lists
-    max.thinning <- max(as.integer(length(tree.list)/21), 2)
+    max.thinning <- max(as.integer(length(tree.list)/10), 2)
 
     # we analyze up to autocorr.intervals thinnings spread evenly, less if there are non-unique numbers
     thinnings <- unique(as.integer(seq(from = 1, to = max.thinning, length.out=autocorr.intervals)))
@@ -153,24 +153,9 @@ path.dist <- function (trees, check.labels = TRUE)
 
 get.sequential.distances <- function(thinning, tree.list, N=100, squared = FALSE, treedist = 'PD'){
     
-    # now thin out the input list
-    keep <- seq(from=1, to=length(tree.list), by=thinning)
-    
-    # first we cut off any trailing trees from the input list
-    if(length(keep)%%2 != 0) keep <- keep[1:(length(keep)-1)]
-    
-    # now we get the indices of the odd elements of keep
-    # we will use these to make a pairwise list of sequential samples
-    odds <- seq(from=1, to=length(keep), by=2)
-    
-    # we only look at N samples, allows for variation in effciency    
-#    if((length(odds))>N){
-#        odds <- sample(odds[1:(length(odds))], N, replace=FALSE)
-#        evens <- odds + 1 # indices of the tree2 trees in keep
-#        indices <- sort(c(odds, evens))
-#        keep <- keep[indices]
-#    }
-    
+    starts = 1:(length(tree.list) - thinning)
+    ends = starts + thinning
+    keep = c(rbind(starts, ends))
     tree.list <- tree.list[keep]
     tree.index <- seq_along(tree.list)
     


### PR DESCRIPTION
because we get more samples that way, and we can estimate
autocorrellation at larger sampling intervals