### PR TITLE
bug fix in clade.freq. Allow to return clade or split (default) frequ…

### DIFF
--- a/R/clade.freq.R
+++ b/R/clade.freq.R
@@ -18,7 +18,7 @@
 #' clade.freq(fungus$Fungus.Run1, start=10, end=100)
 
 # Modified from prop.part in APE, returning data in a more useful format
-clade.freq <- function (x, start, end, check.labels = TRUE) {
+clade.freq <- function (x, start, end, check.labels = TRUE, rooted=FALSE) {
   if(class(x) == "rwty.trees"){x <- x$trees}  
   obj <- list(x[start:end])
   if (length(obj) == 1 && class(obj[[1]]) != "phylo") 
@@ -31,6 +31,7 @@ clade.freq <- function (x, start, end, check.labels = TRUE) {
   for (i in 1:ntree) storage.mode(obj[[i]]$Nnode) <- "integer"
   obj <- .uncompressTipLabel(obj)
   clades <- .Call("prop_part", obj, ntree, TRUE, PACKAGE = "ape")
+  if(!rooted) clades <- postprocess.prop.part(clades)  
   cladefreqs <- as.numeric(as.character(attr(clades, which="number")[1:length(clades)] ))
   cladefreqs <- cladefreqs/ntree
   tiplabels <- as.character(obj[[1]]$tip.label)


### PR DESCRIPTION
Dear @danlwarren  & @roblanf,

it seems there is a major error in the way you compute clade / split frequencies. If the trees were not rooted with an outgroup - as in your examples - the split frequencies `rwty` reports are likely wrong. 
I see from your code you unroot all the trees in the beginning, so you really want to compute split frequencies in general, not clade frequencies. I added an additional argument rooted to `clade.freq` function. If `rooted` is set to `FALSE` (the default) it return the split frequencies, if `TRUE` clade frequencies. This allows to include clade support for rooted trees from (*)BEAST or similar programs later on. The function `postprocess.prop.part` will be much faster in the next `ape` version (3.5).
This may be related to issues #49 and #55. 

Here is an short example, which shows the problem nicely. 
```{r}
library(rwty)
set.seed(42)
tree1 = rtree(4, rooted = FALSE)
tree2 = root(tree1, node=6)
par(mfrow=c(1,2))
plot(tree1)
plot(tree2) # the same tree
x = c(tree1, tree2)
z = c(rep(x[1], 100), rep(x[2], 100))
class(z) = "multiPhylo"
write.nexus(z, file="tmp.nex")
z2 = load.trees("tmp.nex", gens.per.tree = 1)
# there should be only one split
clade.freq(z2, 1, 200)
makeplot.splitfreqs.sliding(z2, n.clades=2)
makeplot.acsf.sliding(z2)
unlink("tmp.nex")
```

PS: I also just uploaded a new version of phangorn. The `treedist` functions are now all available separately, I thought you might interested in this.
