### PR TITLE
Improved makeplot.splitfreq.matrix for scripting usage

### DIFF
--- a/R/makeplot.splitfreq.matrix.R
+++ b/R/makeplot.splitfreq.matrix.R
@@ -29,9 +29,14 @@ makeplot.splitfreq.matrix <- function(chains, burnin = 0){
 
   dat = dat[,(names(dat) %in% names(chains))] #keep only the chain values 
 
+  pdf(NULL)
+  dev.control(displaylist="enable")
+
   pairs2(dat, lower.panel = panel.smooth, upper.panel = panel.cor, pch = 20, col = rgb(0, 0, 1, 0.2))
   title("Split frequency comparisons")
   splitfreq.matrix = recordPlot()
+
+  invisible(dev.off())
 
   if(all(asdsf  == 0)){
     print("No non-zero ASDSF values, skipping ASDSF tree")  


### PR DESCRIPTION
 I added a null device in order to record the splitfreq.matrix plot, avoiding to generate the superfluous Rplots.pdf file when using RWTY in Rscript. The returned recordedplot object ($splitfreq.matrix) can be then easily printed/saved using any device.