### PR TITLE
Common node indexing across clade calculations

### DIFF
--- a/R/clade.freq.R
+++ b/R/clade.freq.R
@@ -1,14 +1,14 @@
 #' Returns clade names and frequencies
-#' 
+#'
 #' Uses ape functionality to get the frequencies and names of clades in an MCMC chain
 #' or subset thereof.
 #'
 #' @param x A multiPhylo or rwty.chain object
 #' @param start The index of the first tree to consider in calcuating frequencies
 #' @param end The index of the last tree to consider in calculating frequencies
-#' @param rooted (TRUE/FALSE).  Tells RWTY whether your trees are rooted or not. 
+#' @param rooted (TRUE/FALSE).  Tells RWTY whether your trees are rooted or not.
 #' @param ... Arguments to be passed to ape's prop.part function
-#' 
+#'
 #' @return clade.df A data froma containing clade names and frequencies
 #'
 #' @keywords Clade frequencies, consensus, mcmc, phylogenetics
@@ -22,36 +22,44 @@
 
 # Modified from prop.part in APE, returning data in a more useful format
 clade.freq <- function (x, start, end, rooted=FALSE, ...) {
-  
+
   if(class(x) == "rwty.chain"){
     x <- x$trees
-  }  
-  
+  }
+
    if (length(x) == 1 && class(x[[1]]) == "multiPhylo"){
      x <- x[[1]]
-   } 
-  
+   }
+
   x <- x[start:end]
- 
+
   clades <-  prop.part(x)
-  
+
+  # Sort tip labels alphabetically and update clade indices to match
+  y <- attr(clades, "labels")
+  z <- sort(y)
+  for (i in seq_along(clades)) {
+      clades[[i]] <- which(z %in% y[clades[[i]]])
+  }
+  attr(clades, "labels") <- z
+
   if(!rooted){
-    clades <- postprocess.prop.part(clades)  
-  } 
-  
+    clades <- postprocess.prop.part(clades)
+  }
+
   cladefreqs <- as.numeric(as.character(attr(clades, which="number")[1:length(clades)] ))
-  
+
   cladefreqs <- cladefreqs/length(x)
-  
+
   tiplabels <- as.character(x[[1]]$tip.label)
-  
+
   cladenames <- rep(NA, length(clades))
-  
+
   for(i in 1:length(clades)){
     cladenames[i] <- paste(clades[[i]], collapse=" ")
   }
-  
-  clade.df <- data.frame(cladenames, cladefreqs)  
-  
+
+  clade.df <- data.frame(cladenames, cladefreqs)
+
   return(clade.df)
 }

--- a/R/parse.slide.clades.R
+++ b/R/parse.slide.clades.R
@@ -1,0 +1,23 @@
+#' Rename clades for easy recall
+#'
+#' Converts a list of clades (e.g., "1 2 3 4" as a clade) and
+#' returns a list of parsed clades, converting numbers to names using a set of trees.
+#' Called internally by the slide and cumulative analyses, not user-facing.
+#'
+#' @param clades A list of clades, as in the first column of a cladetable in an rwty.slide or rwty.cumulative object.
+#' @param treelist A list of trees, used for getting tip names.
+#'
+#' @return output A list of clades with parsed tip names
+
+
+parse.slide.clades <- function(clades, treelist){
+    output <- vector(mode = "character", length = length(clades))
+    for(i in 1:length(clades)){
+        # Convert factor to set of indices
+        nums <- as.numeric(unlist(strsplit(as.character(clades[i]),
+                                           split = " ")))
+        # Convert indices to tip names
+        output[i] <- paste(nums, collapse = ", ")
+    }
+    output
+}

--- a/R/slide.freq.R
+++ b/R/slide.freq.R
@@ -1,11 +1,11 @@
 #' Sliding window measurements of clade split frequencies.
-#' 
+#'
 #' This function takes sliding windows of a specified length over an MCMC chain
 #' and calculates the split frequency of clades within that window.  It
 #' allows users to see whether the chain is visiting different areas of treespace.
 #'
-#' @param chains A list of rwty.chain objects. 
-#' @param burnin The number of trees to eliminate as burnin. Defaults to zero. 
+#' @param chains A list of rwty.chain objects.
+#' @param burnin The number of trees to eliminate as burnin. Defaults to zero.
 #' @param window.size The number of trees to include in each window (note, specified as a number of sampled trees, not a number of generations)
 #'
 #' @return A list of rwty.slide objects, one per chain in the input list of chains.
@@ -21,7 +21,7 @@
 #' slide.data <- slide.freq(fungus, burnin=20)\
 #' }
 
-slide.freq <- function(chains, burnin=0, window.size = 20){ 
+slide.freq <- function(chains, burnin=0, window.size = 20){
 
     chains = check.chains(chains)
     trees = lapply(chains, function(x) x[['trees']])
@@ -52,7 +52,7 @@ get.slide.freq.table <- function(tree.list, burnin = 0, window.size = 20, gens.p
 
     # now we calculate clade frequencies on each of the lists of trees
     clade.freq.list = lapply(tree.windows, clade.freq, start=1, end=window.size)
-    
+
     # and rename the list to the first tree of each window
     names(clade.freq.list) = prettyNum(seq((burnin + 1),(burnin + length(clade.freq.list) * window.size), by=window.size)*gens.per.tree, sci=TRUE)
 
@@ -70,32 +70,30 @@ get.slide.freq.table <- function(tree.list, burnin = 0, window.size = 20, gens.p
     slide.freq.table[is.na(slide.freq.table)] = 0.0
     rownames(slide.freq.table) = slide.freq.table$cladenames
     slide.freq.table = slide.freq.table[,-1]
-    
+
     # calculate sd and mean of cumulative frequency and mean
     thissd = apply(slide.freq.table, 1, sd)
-    thismean = apply(slide.freq.table, 1, mean) 
+    thismean = apply(slide.freq.table, 1, mean)
     thisess = apply(slide.freq.table, 1, effectiveSize)
 
     slide.freq.table$sd = thissd
     slide.freq.table$mean = thismean
     slide.freq.table$ess = thisess
-   
+
     # Sorting by sd, since these are usually the most interesting clades
     slide.freq.table = slide.freq.table[order(slide.freq.table$sd, decreasing=TRUE),]
-    
+
     # Building a new table that contains parsed clade names
-    translation.table = cbind(as.numeric(as.factor(rownames(slide.freq.table))), 
-                                as.character(rownames(slide.freq.table)), 
-                                parse.clades(rownames(slide.freq.table), tree.list))
+    translation.table = cbind(as.numeric(as.factor(rownames(slide.freq.table))),
+                                as.character(rownames(slide.freq.table)),
+                                parse.slide.clades(rownames(slide.freq.table), tree.list))
     colnames(translation.table) = c("Clade number", "Tip numbers", "Tip names")
-    
+
     # Seting slide.freq.table to the same names as the translation table
     rownames(slide.freq.table) = as.numeric(as.factor(rownames(slide.freq.table)))
-    
+
     output <- list("slide.table" = slide.freq.table, "translation" = translation.table)
     class(output) <- "rwty.slide"
-    
+
     return(output)
 }
-
-   


### PR DESCRIPTION
Possible fix for https://github.com/danlwarren/RWTY/issues/173#issue-972361743

We use the alphabetical order of tip labels to be consistent across getting the clades in each window and tree list as well as building the translation table. Now if `prop.part` produces a clade `1 2 3` and key `1 d, 2 b, 3 a, 4 c` then it will be changed to `1 2 4` with key `1 a, 2 b, 3 c, 4 d` before post-processing. The `parse.slide.clades` function is almost a duplicate of `parse.clades`, I didn't change it as it's used elsewhere in the package.