### PR TITLE
Identify split containing all tips by comparing lengths

### DIFF
--- a/R/clade.freq.R
+++ b/R/clade.freq.R
@@ -60,8 +60,7 @@ clade.freq <- function (x, start, end, rooted=FALSE, ...) {
   }
 
   # dropping split corresponding to all tips
-  clade.all <- paste(seq_along(attr(clades, "labels")), collapse = " ")
-  ind.all <- which(clade.all %in% cladenames)
+  ind.all <- which(sapply(clades, length) == length(x[[1]]$tip.label))
   if (!(length(ind.all) == 1 && cladefreqs[ind.all] == 1)) {
       warning("unable to find trivial split of all tips")
   }


### PR DESCRIPTION
Improved fix for #177 using the number of tips in a split to identify the trivial one containing all of them, rather than comparing strings like in #178.